### PR TITLE
Remove unused JSON encoding import from organizer.go

### DIFF
--- a/pkg/organizer/organizer.go
+++ b/pkg/organizer/organizer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dsoprea/go-exif/v3"
 	"github.com/tidwall/gjson"
 
-	"encoding/json"
 	"runtime/debug"
 )
 


### PR DESCRIPTION
This pull request makes a minor change to the import statements in `pkg/organizer/organizer.go`, specifically removing an unused import.

* Removed the unused `encoding/json` import from `pkg/organizer/organizer.go` to clean up the code.